### PR TITLE
Add GitHub Action for building on Windows, macOS and Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build crankshaft
+
+on: push
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Install g++-multilib
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt update && sudo apt install g++-multilib
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '16.14.2'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build and release if the draft exists
+        run: npm run dist
+        env:
+          GH_TOKEN: ${{ secrets.github_token }}

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "build": "tsc",
     "watch": "tsc -w",
     "start": "npm run build && electron .",
-    "dist": "npm run build && electron-builder --win --linux",
-    "macdist": "npm run build && electron-builder -m",
+    "dist": "npm run build && electron-builder",
     "release": "electron-builder --publish always",
     "postinstall": "electron-builder install-app-deps"
   },


### PR DESCRIPTION
This PR adds a workflow file for building and automatically uploading them to draft releases.

Note that this won't work on macOS (yet) because the `icon.png` on macOS [must be at least 512x512](https://www.electron.build/icons.html).
As I don't have the source file for the `icon.png`, I decided to leave it for you to update the icon file to a proper one.