### PR TITLE
fix: hide #aContainer in hub

### DIFF
--- a/assets/hideAds.css
+++ b/assets/hideAds.css
@@ -2,7 +2,8 @@
 #aHider,
 #adCon,
 #rightABox,
-#aContainer
+#aContainer,
+div#aContainer,
 #braveWarning {
     display: none !important
 }


### PR DESCRIPTION
A new selector is added, `div#aContainer`, which is more specific than the one that Krunker uses. This fixes #17 