### PR TITLE
chore: use pnpm/action-setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,3 +35,4 @@ jobs:
         run: pnpm run dist
         env:
           GH_TOKEN: ${{ secrets.github_token }}
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,16 +20,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 'latest'
-
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
           version: latest
-          run_install: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 'latest'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
 
       - name: Build and release if the draft exists
         run: pnpm run dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,4 +35,3 @@ jobs:
         run: pnpm run dist
         env:
           GH_TOKEN: ${{ secrets.github_token }}
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,11 @@ jobs:
         with:
           node-version: 'latest'
 
-      - name: Install dependencies
-        run: |
-          npm install --global pnpm
-          pnpm install
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: latest
+          run_install: true
 
       - name: Build and release if the draft exists
         run: pnpm run dist


### PR DESCRIPTION
Use GitHub Action provided by pnpm instead of manually installing pnpm using npm.
This PR will also setup caching pnpm dependencies.
See https://pnpm.io/continuous-integration#github-actions

please dont mind scuffed commits im too lazy to setup act :sob: (get squashed idiots)