### PR TITLE
Social CSS Swapper + Keybind Setting Reset

### DIFF
--- a/assets/settings.css
+++ b/assets/settings.css
@@ -429,6 +429,21 @@ input:checked+.advancedSlider:hover {
 	transition: 0s;
 }
 
+.crankshaftKeybindSettingWrapper {
+	display: flex;
+}
+
+.material-icons.crankshaftUnbindButton {
+	color: red;
+	font-size: 2em !important;
+	padding-left: 0.2em;
+}
+
+.crankshaftUnbindButton:hover {
+	cursor: pointer;
+	transform: scale(1.2);
+}
+
 /* Match Result Copy Button Styles */
 .matchResultButton {
 	position: absolute;

--- a/esbuilder.js
+++ b/esbuilder.js
@@ -8,8 +8,9 @@ const watching = args.includes("--watch")
 const metaFile = args.includes("--meta")
 console.log("building(minifying):", building, "watching:", watching)
 
-fs.rmSync("app/main.js", { force: true })
-fs.rmSync("app/preload.js", { force: true })
+fs.rmSync("app/main.js", { force: true });
+fs.rmSync("app/preload.js", { force: true });
+fs.rmSync("app/socialpreload.js", { force: true });
 
 /**
  * @type {import('esbuild').Plugin}
@@ -28,7 +29,8 @@ const buildOptions = {
 	// keep this manually in-sync!
 	entryPoints: [
 		'src/main.ts',
-		'src/preload.ts'
+		'src/preload.ts',
+		'src/socialpreload.ts'
 	],
 	bundle: true,
 	minify: building,

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import RequestHandler from './requesthandler';
 const userData = pathJoin(app.getPath('userData'), 'config');
 const docsPath = pathJoin(app.getPath('documents'), 'Crankshaft'); // pre 1.9.0 settings path
 const configPath = userData;
+const windowScale = 0.8; // In windowed mode, the window will cover 80% of the height/width of the screen. 
 
 /*
  * TODO make crankshaft server announcement about backup
@@ -50,7 +51,9 @@ const filtersPath = pathJoin(configPath, 'filters.txt');
 const userscriptsPath = pathJoin(configPath, 'scripts');
 const userscriptTrackerPath = pathJoin(userscriptsPath, 'tracker.json');
 const cssPath = pathJoin(configPath, 'css');
+const socialCssPath = pathJoin(configPath, 'socialcss');
 const exampleCssPath = pathJoin(cssPath, 'example.css');
+const exampleSocialCssPath = pathJoin(socialCssPath, 'example.css');
 
 app.userAgentFallback = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.0 Electron/12.0.0-nightly.20201116 Safari/537.36';
 
@@ -64,6 +67,8 @@ const settingsSkeleton = {
 	fullscreen: 'windowed', // windowed, maximized, fullscreen, borderless
 	resourceSwapper: true,
 	cssSwapper: 'None',
+	socialCssSwapper: 'None',
+	socialTabBehaviour: 'Same Window' as 'Same Window' | 'New Window',
 	userscripts: false,
 	clientSplash: true,
 	immersiveSplash: false,
@@ -122,7 +127,15 @@ if (!existsSync(cssPath)) mkdirSync(cssPath);
 if (!existsSync(exampleCssPath)) {
 	writeFileSync(exampleCssPath,
 		`/* This is an example of a css file that can be loaded by Crankshaft. */
-/* Files in this directory automatically show up in the css swapper setting's dropdown. */`);
+/* Files in this directory automatically show up in the CSS Swapper setting's dropdown. */`);
+}
+
+if (!existsSync(socialCssPath)) mkdirSync(socialCssPath);
+
+if (!existsSync(exampleSocialCssPath)) {
+	writeFileSync(exampleSocialCssPath,
+		`/* This is an example of a css file that can be loaded by Crankshaft. */
+/* Files in this directory automatically show up in the Social CSS Swapper setting's dropdown. */`);
 }
 
 Object.assign(userPrefs, JSON.parse(readFileSync(settingsPath, { encoding: 'utf-8' })));
@@ -147,7 +160,8 @@ if (typeof userPrefs.hideAds === 'boolean') {
 if (modifiedSettings) writeFileSync(settingsPath, JSON.stringify(userPrefs, null, 2), { encoding: 'utf-8' });
 
 let mainWindow: BrowserWindow;
-let socialWindowReference: BrowserWindow;
+let mainSocialWindowReference: BrowserWindow;
+let allSocialWindows: BrowserWindow[] = [];
 
 ipcMain.on('logMainConsole', (event, ...data) => { console.log(...data); });
 
@@ -158,7 +172,7 @@ ipcMain.on('initializeUserscripts', () => {
 
 // initial request of settings to populate the settingsUI
 ipcMain.on('settingsUI_requests_userPrefs', () => {
-	const paths = { settingsPath, swapperPath, cssPath, filtersPath, userscriptPreferencesPath, configPath, userscriptsPath };
+	const paths = { settingsPath, swapperPath, cssPath, socialCssPath, filtersPath, userscriptPreferencesPath, configPath, userscriptsPath };
 	mainWindow.webContents.send('m_userPrefs_for_settingsUI', paths, userPrefs);
 });
 
@@ -169,6 +183,13 @@ ipcMain.on('matchmaker_requests_userPrefs', () => {
 
 // settingsui is sending back updated settings (user changed the settings in ui) - writing new settings is already handled.
 ipcMain.on('settingsUI_updates_userPrefs', (event, data) => {
+	if (data?.socialCssSwapper && data.socialCssSwapper !== userPrefs.socialCssSwapper) {
+		// if the new social CSS is different from the old social CSS, swap CSS on social windows if they exist
+		for (const socialWindow of allSocialWindows) {
+			socialWindow.webContents.send('new_social_css', `${data.socialCssSwapper}`);
+		}
+	}
+
 	Object.assign(userPrefs, data);
 });
 
@@ -179,14 +200,17 @@ const $assets = pathResolve(__dirname, '..', 'assets');
 const hideAdsCSS = readFileSync(pathJoin($assets, 'hideAds.css'), { encoding: 'utf-8' });
 
 /** open a custom generic window with our menu, hidden */
-function customGenericWin(url: string, providedMenuTemplate: (MenuItemConstructorOptions | MenuItem)[], addAdditionalSubmenus = true) {
+function customGenericWin(url: string, providedMenuTemplate: (MenuItemConstructorOptions | MenuItem)[], addAdditionalSubmenus = true, addDevtools = true, customPreload: string | false = false) {
+	const screenSize = screen.getPrimaryDisplay().size;
+
 	const genericWin = new BrowserWindow({
 		autoHideMenuBar: true,
 		show: false,
-		width: 1600,
-		height: 900,
+		width: screenSize.width * windowScale,
+		height: screenSize.height * windowScale,
 		center: true,
 		webPreferences: {
+			preload: (customPreload) ? customPreload : '',
 			spellcheck: false,
 			enableRemoteModule: false,
 			nodeIntegration: false
@@ -216,9 +240,12 @@ function customGenericWin(url: string, providedMenuTemplate: (MenuItemConstructo
 					if (genericWin.webContents.canGoForward()) genericWin.webContents.goForward();
 				}
 			},
-			{ type: 'separator' },
-			...constructDevtoolsSubmenu(genericWin, userPrefs.alwaysWaitForDevTools || null)
+			{ type: 'separator' }
 		]);
+	}
+
+	if (addDevtools && Array.isArray(submenu)) {
+		submenu.push(...constructDevtoolsSubmenu(genericWin, userPrefs.alwaysWaitForDevTools || null));
 	}
 
 	const thisMenu = Menu.buildFromTemplate(providedMenuTemplate);
@@ -261,10 +288,12 @@ app.on('ready', () => {
 
 	if (userPrefs.resourceSwapper) protocol.registerFileProtocol('krunker-resource-swapper', (request, callback) => callback(decodeURI(request.url.replace(/krunker-resource-swapper:/u, ''))));
 
+	const screenSize = screen.getPrimaryDisplay().size;
+
 	const mainWindowProps: BrowserWindowConstructorOptions = {
 		show: false,
-		width: 1600,
-		height: 900,
+		width: screenSize.width * windowScale,
+		height: screenSize.height * windowScale,
 		center: true,
 		webPreferences: {
 			preload: pathJoin(__dirname, 'preload.js'),
@@ -405,15 +434,17 @@ app.on('ready', () => {
 	mainWindow.setMenuBarVisibility(false);
 
 	mainWindow.webContents.on('new-window', (event, url) => {
-		console.log('url trying to open:', url, 'socialWindowReference:', typeof socialWindowReference);
+		console.log('url trying to open:', url, 'socialWindowReference:', typeof mainSocialWindowReference);
 		const freeSpinHostnames = ['youtube.com', 'twitch.tv', 'twitter.com', 'reddit.com', 'discord.com', 'accounts.google.com', 'instagram.com', 'github.com'];
 
 		// sanity check, if social window is destroyed but the reference still exists
-		if (typeof socialWindowReference !== 'undefined' && socialWindowReference.isDestroyed()) socialWindowReference = void 0;
+		if (typeof mainSocialWindowReference !== 'undefined' && mainSocialWindowReference.isDestroyed()) mainSocialWindowReference = void 0;
 
-		if (url.includes('social.html') && typeof socialWindowReference !== 'undefined') {
+		if (url.includes('social.html') && typeof mainSocialWindowReference !== 'undefined') {
+			// This runs when a social tab is already open and the user tries to open another social tab from the main game.
 			event.preventDefault();
-			socialWindowReference.loadURL(url); // if a designated socialWindow exists already, just load the url there
+			mainSocialWindowReference.loadURL(url); // if a designated socialWindow exists already, just load the url there
+			mainSocialWindowReference.show(); // bring the window to the front for if the user forgot if they had a social tab open (I've totally never done that ever)
 		} else if (freeSpinHostnames.some(fsUrl => url.includes(fsUrl))) {
 			const pick = dialog.showMessageBoxSync({
 				title: 'Opening a new url',
@@ -447,30 +478,26 @@ app.on('ready', () => {
 			|| url.includes('beta.krunker.io')
 			|| url.startsWith('https://krunker.io/?game')
 			|| url.startsWith('https://krunker.io/?play')
+			|| url.endsWith('?sandbox')
+			|| url.includes('?host')
 			|| (url.includes('?game=') && url.includes('&matchId='))
 		) {
 			event.preventDefault();
 			mainWindow.loadURL(url);
-		} else { // for any other link, fall back to creating a custom window with strippedMenu. 
+		} else {
 			event.preventDefault();
-			console.log(`genericWindow created for ${url}`, socialWindowReference);
-			const genericWin = customGenericWin(url, strippedMenuTemplate);
-			event.newGuest = genericWin;
+			console.log(`genericWindow created for ${url}`);
+			if (url.includes('social.html')) { // for social links, create a separate "master" social window that the main game will reference.
+				const newMainSocialWindow = customGenericWin(url, strippedMenuTemplate, false, true, pathJoin(__dirname, 'socialpreload.js'));
+				event.newGuest = newMainSocialWindow;
 
-			// if the window is social, create and assign a new socialWindow
-			if (url.includes('social.html')) {
-				socialWindowReference = genericWin;
+				mainSocialWindowReference = newMainSocialWindow;
 				// eslint-disable-next-line no-void
-				genericWin.on('close', () => { socialWindowReference = void 0; }); // remove reference once window is closed
-
-				genericWin.webContents.on('will-navigate', (evt, willnavUrl) => { // new social pages will just replace the url in this one window
-					if (willnavUrl.includes('social.html')) {
-						genericWin.loadURL(willnavUrl);
-					} else {
-						evt.preventDefault();
-						shell.openExternal(willnavUrl);
-					}
-				});
+				newMainSocialWindow.on('close', () => { mainSocialWindowReference = void 0; }); // remove reference once window is closed
+				bindSocialWindowBehaviours(newMainSocialWindow);
+			} else { // for any other link, fall back to creating a custom window with strippedMenu. 
+				const genericWin = customGenericWin(url, strippedMenuTemplate, false, true);
+				event.newGuest = genericWin;
 			}
 		}
 	});
@@ -488,6 +515,46 @@ app.on('ready', () => {
 		CrankshaftFilterHandlerInstance.start();
 	}
 });
+
+/**
+ * Binds social/hub window behaviours to a window. This includes navigation, closing, window tracking, and preload options.
+ * @param windowToBind The BrowserWindow that needs to have social/hub behaviours bound.
+ */
+function bindSocialWindowBehaviours(windowToBind: BrowserWindow) {
+	allSocialWindows.push(windowToBind);
+
+	windowToBind.webContents.on('will-navigate', (evt, willnavUrl) => { // new social pages will just replace the url in this one window
+		if (willnavUrl.includes('social.html')) {
+			windowToBind.loadURL(willnavUrl);
+		} else {
+			evt.preventDefault();
+			shell.openExternal(willnavUrl);
+		}
+	});
+
+	windowToBind.on('closed', () => {
+		allSocialWindows = allSocialWindows.filter(socialWindow => !socialWindow.isDestroyed());
+		console.log(`Social Window Closed. Total Social Windows: ${allSocialWindows.length}`);
+	})
+
+	windowToBind.on("ready-to-show", () => {
+		windowToBind.webContents.send('social_tab_data', { userPrefs, socialCssPath });
+	});
+
+	windowToBind.webContents.on('new-window', (evt, url) => {
+		console.log('Social tab tried to open a child window:', url);
+		if (userPrefs.socialTabBehaviour === "Same Window") {
+			evt.preventDefault();
+			windowToBind.loadURL(url);
+		} else if (userPrefs.socialTabBehaviour === "New Window") {
+			console.log('Creating new social window.');
+			evt.preventDefault();
+			const newSocialWindow = customGenericWin(url, [...macAppMenuArr, genericMainSubmenu, ...csMenuTemplate], false, true, pathJoin(__dirname, 'socialpreload.js'));
+			bindSocialWindowBehaviours(newSocialWindow);
+			evt.newGuest = newSocialWindow;
+		}
+	})
+}
 
 // for the 2nd attempt at fixing the memory leak, i am just going to rely on standard electron lifecycle logic - when all windows close, the app should exit itself
 // eslint-disable-next-line consistent-return

--- a/src/settingsui.ts
+++ b/src/settingsui.ts
@@ -29,6 +29,37 @@ let paths: IPaths;
 
 document.addEventListener('DOMContentLoaded', () => { ipcRenderer.send('settingsUI_requests_userPrefs'); });
 
+// Swapper options are declared here so that TS knows they are the correct type for modifications under the m_userPrefs_for_settingUI message
+const cssSwapperOption: SelectSettingDescItem = {
+	title: 'CSS Swapper',
+	type: 'sel',
+	desc: 'Load and swap between CSS files',
+	safety: 0,
+	cat: 1,
+	instant: true,
+	opts: [],
+	button: {
+		icon: 'folder',
+		text: 'CSS',
+		callback: e => openPath(e, paths.cssPath)
+	}
+}
+
+const socialCssSwapperOption: SelectSettingDescItem = {
+	title: 'Social CSS Swapper',
+	type: 'sel',
+	desc: 'Load and swap between CSS files on the Krunker Hub',
+	safety: 0,
+	cat: 1,
+	instant: true,
+	opts: [],
+	button: {
+		icon: 'folder',
+		text: 'Social CSS',
+		callback: e => openPath(e, paths.socialCssPath)
+	}
+}
+
 ipcRenderer.on('m_userPrefs_for_settingsUI', (event, recieved_paths: IPaths, recieved_userPrefs: UserPrefs) => {
 	// main sends us the path to settings and also settings themselves on initial load.
 	userPrefsPath = recieved_paths.settingsPath;
@@ -40,10 +71,12 @@ ipcRenderer.on('m_userPrefs_for_settingsUI', (event, recieved_paths: IPaths, rec
 	settingsDesc.resourceSwapper.button = { icon: 'folder', text: 'Swapper', callback: e => openPath(e, paths.swapperPath) };
 	settingsDesc.customFilters.button = { icon: 'filter_list', text: 'Filters file', callback: e => openPath(e, paths.filtersPath) };
 	settingsDesc.userscripts.button = { icon: 'folder', text: 'Scripts', callback: e => openPath(e, paths.userscriptsPath) };
-	settingsDesc.cssSwapper.button = { icon: 'folder', text: 'CSS', callback: e => openPath(e, paths.cssPath) };
 
-	settingsDesc.cssSwapper.opts = ['None', ...readdirSync(paths.cssPath)];
-	if (!settingsDesc.cssSwapper.opts.includes(userPrefs.cssSwapper)) userPrefs.cssSwapper = 'None';
+	cssSwapperOption.opts = ['None', ...readdirSync(paths.cssPath).filter(path => path.endsWith('.css'))];
+	if (!cssSwapperOption.opts.includes(`${userPrefs.cssSwapper}`)) userPrefs.cssSwapper = 'None';
+
+	socialCssSwapperOption.opts = ['None', ...readdirSync(paths.socialCssPath).filter(path => path.endsWith('.css'))];
+	if (!socialCssSwapperOption.opts.includes(`${userPrefs.socialCssSwapper}`)) userPrefs.socialCssSwapper = 'None';
 });
 
 /** joins the data: userPrefs and Desc: SettingsDesc into one array of objects */
@@ -88,8 +121,10 @@ const settingsDesc: SettingsDesc = {
 	customFilters: { title: 'Custom Filters', type: 'bool', desc: 'Enable custom network filters. ', safety: 0, cat: 0, refreshOnly: true },
 	saveMatchResultJSONButton: { title: 'Match Result To Clipboard', type: 'bool', desc: 'New button on match end which copies the match results JSON.', safety: 0, cat: 0, refreshOnly: true },
 	userscripts: { title: 'Userscript support', type: 'bool', desc: `Enable userscript support. read <a href="https://github.com/${repoID}/blob/master/USERSCRIPTS.md" target="_blank">USERSCRIPTS.md</a> for more info.`, safety: 1, cat: 0 },
+	socialTabBehaviour: { title: 'Social/Hub Tab Behaviour', type: 'sel', desc: "Defines how new social tabs are handled. 'Same Window' will only keep one social tab open at any time. 'New Window' will open new browser windows for every tab.", safety: 0, cat: 0, opts: ['Same Window', 'New Window'], instant: true },
 
-	cssSwapper: { title: 'CSS Swapper', type: 'sel', desc: 'Load and swap between CSS files', safety: 0, cat: 1, instant: true, opts: [] },
+	cssSwapper: cssSwapperOption,
+	socialCssSwapper: socialCssSwapperOption,
 	menuTimer: { title: 'Menu Timer', type: 'bool', safety: 0, cat: 1, instant: true },
 	hideReCaptcha: { title: 'Hide reCaptcha', type: 'bool', safety: 0, cat: 1, instant: true },
 	quickClassPicker: { title: 'Quick Class Picker', type: 'bool', safety: 0, cat: 1, instant: true },
@@ -355,9 +390,10 @@ class SettingElem {
 				break;
 			case 'keybind':
 				this.HTML += `<span class="setting-title">${sanitize(props.title)}</span> 
-					<label class="setting-input-wrapper">
+					<label class="setting-input-wrapper crankshaftKeybindSettingWrapper">
 							<input class="s-update keybinddummyinput" type="text" />
 							<span class="keyIcon crankshaftKeyIcon">${ parseKeybindSettingDisplay(props.value as KeybindUserPref) }</span>
+							<span class="material-icons crankshaftUnbindButton">delete_forever</span>
 					</label>`;
 				this.updateKey = 'value';
 				this.updateMethod = 'onchange';
@@ -423,6 +459,9 @@ class SettingElem {
 				const cssElem = document.getElementById('crankshaftCustomCSS');
 				const cssFile = readFileSync(join(paths.cssPath, value), { encoding: 'utf-8' });
 				cssElem.textContent = cssFile;
+			} else if (this.props.key === 'cssSwapper' && value === 'None') {
+				const cssElem = document.getElementById('crankshaftCustomCSS');
+				cssElem.textContent = '';
 			}
 
 			// you can add custom instant refresh callbacks for settings here
@@ -505,6 +544,15 @@ class SettingElem {
 			})
 			// The reason we do this is to transmit the value when updating the value, since there's no <input> for JS objects themselves.
 			wrapper.querySelector('input').setAttribute("value", JSON.stringify(this.props.value));
+
+			wrapper.querySelector('.crankshaftUnbindButton').addEventListener('mousedown', (event) => {
+				setKeybindSetting(this, {
+					shift: false,
+					alt: false,
+					ctrl: false,
+					key: 'NONE'
+				})
+			})
 		}
 
 		if (typeof this.props.callback === 'undefined') this.props.callback = 'normal'; // default callback
@@ -574,6 +622,12 @@ keybindSettingDialogElement.appendChild(keybindSettingDialogCard);
 */
 const activeIndicatorClass = 'activeIndicator';
 
+function setKeybindSetting(settingElem: SettingElem, setting: KeybindUserPref) {
+	// We transmit the change through the <input> element to keep the flow the same; there's no <input> for JS objects themselves.
+	settingElem.elem.querySelector('input').setAttribute("value", JSON.stringify(setting));
+	settingElem.update(settingElem.elem, settingElem.props.callback);
+}
+
 /**
  * The handler for key rebinding. This is where the setting is updated and the reset function is called.
  * @param event KeyboardEvent that triggered the keybind dialog listener
@@ -586,9 +640,7 @@ function keybindSettingDialogListener(event: KeyboardEvent) {
 			removeKeybindSettingDialog();
 		} else {
 			const capturedSetting = turnKeyboardEventIntoSettingValue(event);
-			// We transmit the change through the <input> element to keep the flow the same; there's no <input> for JS objects themselves.
-			capturingKeybindSetting.elem.querySelector('input').setAttribute("value", JSON.stringify(capturedSetting));
-			capturingKeybindSetting.update(capturingKeybindSetting.elem, capturingKeybindSetting.props.callback);
+			setKeybindSetting(capturingKeybindSetting, capturedSetting);
 			removeKeybindSettingDialog();
 		}
 	}

--- a/src/socialpreload.ts
+++ b/src/socialpreload.ts
@@ -1,0 +1,51 @@
+import { join as pathJoin } from 'path';
+import { ipcRenderer } from 'electron';
+import { createElement } from './utils';
+import { readFileSync } from 'fs';
+
+
+const strippedConsole = {
+    log: console.log.bind(console)
+}
+
+ipcRenderer.send('logMainConsole', `[Social/Hub Window] Ran social preload.`);
+
+// Create the element here so that it can be modified by both updaters without creating a new element
+const styleElement = createElement('style', { id: 'crankshaftCustomCSS' });
+
+// Stores the CSS path for when everything is loaded and ready
+let socialCssPath = '';
+
+// userPrefs and the social CSS path are sent here
+ipcRenderer.once('social_tab_data', (event, data) => {
+    const { socialCssSwapper } = data.userPrefs;
+    socialCssPath = data.socialCssPath;
+
+    ipcRenderer.send('logMainConsole', `[Social/Hub Window] Social Tab Received Userprefs.`);
+
+    addEventListener('DOMContentLoaded', (event) => {
+        document.body.appendChild(styleElement);
+        updateSocialCSS(socialCssSwapper);
+    });
+})
+
+ipcRenderer.on('new_social_css', (event, data) => {
+    // hot-swap CSS functionality
+    updateSocialCSS(data);
+})
+
+/**
+ * Changes the active CSS
+ * @param CSSPath Filename of the new desired CSS (or "None" if no CSS is desired)
+ */
+function updateSocialCSS(CSSPath: string) {
+    ipcRenderer.send('logMainConsole', `[Social/Hub Window] Social Tab Updated CSS: ${CSSPath}`);
+    if (CSSPath === 'None') {
+        styleElement.textContent = '';
+    } else {
+        const cssInUse = readFileSync(pathJoin(socialCssPath, `${CSSPath}`), { encoding: 'utf-8' });
+        styleElement.textContent = cssInUse;
+    }
+}
+
+strippedConsole.log('Social Tab Preload Ran.');

--- a/src/splashscreen.ts
+++ b/src/splashscreen.ts
@@ -158,7 +158,11 @@ const possibleSplashFlavors: string[] = [
 	'Forklift Certified.',
 	'...is not a palendrome.',
 	'Big if true.',
-	'Evasive maneuvers!'
+	'Evasive maneuvers!',
+	"I'm the main character!",
+	'Da svidaniya, darling!',
+	'SI SI SI SI SI',
+	'Who up?'
 ];
 
 const splashFlavor = possibleSplashFlavors[Math.floor(Math.random() * possibleSplashFlavors.length)];


### PR DESCRIPTION
- Fixed the Model Viewer not opening in a new window
- Fixed social/hub window not respecting defined options after the second child window
- Fixed hosting games opening the game in a second window (while the main window "loads" indefinitely)
- Fixed the sandbox not opening in the main window
- Fixed the 'windowed' option in "Start in Windowed/Fullscreen mode" not respecting large/small resolutions (I was confused as to why the game would open in such a small window on 1440p, this is why; the resolution to open in was hardcoded)
- Fixed not being able to open devtools on the first opened social/hub window
- Added a preload file for hub/social window (might be useful for tabs in the future?)
- Added settings for a social CSS swapper (hot-swaps css for all open social/hub windows)
- Added social/hub window behaviour option
- Added a socialcss folder for social/hub CSS files
- Added a trashcan next to keybind options to "unbind" the key.
- Made the main social window move itself to the front if it was called upon again by the main game while it was already open
- Renamed the socialWindowReference variable in main.ts to better match the new window behaviour
- Split the CSS Swapper option into its own variable
- Added a handful of splash screeen flavors
![image](https://github.com/user-attachments/assets/326b0080-be54-46de-a1eb-229de134b960)
![image](https://github.com/user-attachments/assets/3cb4aea3-1035-4a30-9be8-b6ad9f608de9)
