### PR TITLE
Matchmaker Keybinds + Keybind polish

### DIFF
--- a/USERSCRIPTS.md
+++ b/USERSCRIPTS.md
@@ -363,7 +363,15 @@ this.settings = {
 ```
 The `shift`, `ctrl`, and `alt` properties of `value` control the key modifiers. You don't *have* to support these modifiers in your script, but crankshaft will still display those modifiers in the settings page.
 NOTE: The '`key`' property comes from [event.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key), so make sure your handlers match `event.key`, NOT `event.code`.
-NOTE: You will have to create your own `KeyboardEvent` listeners in your script.
+NOTE: You will have to create your own `KeyboardEvent` listeners in your script. 
+
+Tip: When making these event listeners, you may want to exclude keyboard events that are created while the user is focused on the chat window. You can do this by checking `document.activeElement`.
+```js
+document.addEventlistener("keydown", (keyboardEvent) => {
+	if (document.activeElement.tagName == "INPUT") return; // Don't do anything with inputs while the user is focused on an input element (like the chat message window)
+	// Handle keyboard input
+})
+```
 
 Custom Settings Implementation Examples:
 [customsettingsexample.js](./assets/userscriptexamples/customsettingsexample.js)

--- a/assets/matchmaker.css
+++ b/assets/matchmaker.css
@@ -8,11 +8,15 @@
     }
 }
 
+.onGame #matchmakerPopupContainer {
+    opacity: 0 !important;
+}
+
 #matchmakerPopupContainer {
     position: absolute;
     top: 10em;
     left: 50%;
-    z-index: 10;
+    z-index: 10000000000000000000;
     box-sizing: border-box;
     width: 35em;
     aspect-ratio: 2.5/1;

--- a/assets/settings.css
+++ b/assets/settings.css
@@ -444,6 +444,21 @@ input:checked+.advancedSlider:hover {
 	transform: scale(1.2);
 }
 
+.crankshaftKeybindConflict.hidden {
+	display: none;
+}
+
+.crankshaftKeybindConflict {
+	color: #ffad00;
+	font-size: 1.4em !important;
+	margin: 0.1em 0.6em;
+	box-sizing: border-box;
+	border: 2px solid;
+	padding: 0.1em 0.2em;
+	border-radius: 0.2em;
+	cursor: help;
+}
+
 /* Match Result Copy Button Styles */
 .matchResultButton {
 	position: absolute;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -136,7 +136,7 @@ interface TextSettingDescItem extends SettingItemGeneric {
 // num has to have a min and max
 interface NumSettingItem extends SettingItemGeneric { type: 'num', min?: number, max?: number }
 
-type SettingsDescItem = (SettingItemGeneric | NumSettingItem | SelectSettingDescItem | MultiselectSettingDescItem | TextSettingDescItem);
+type SettingsDescItem = (SettingItemGeneric | NumSettingItem | SelectSettingDescItem | MultiselectSettingDescItem | TextSettingDescItem | KeybindSettingDescItem);
 
 /** array of SettingDescItem objects */
 interface SettingsDesc {

--- a/src/main.ts
+++ b/src/main.ts
@@ -92,6 +92,18 @@ const settingsSkeleton = {
 		ctrl: false,
 		key: "F1"
 	},
+	matchmakerAcceptKey: {
+		shift: false,
+		alt: false,
+		ctrl: false,
+		key: "Enter"
+	},
+	matchmakerCancelKey: {
+		shift: false,
+		alt: false,
+		ctrl: false,
+		key: "Escape"
+	},
 	matchmaker_openServerWindow: true,
 	matchmaker_regions: [] as string[],
 	matchmaker_gamemodes: [] as string[],


### PR DESCRIPTION
- Added options to change matchmaker keybindings
- Added "keybinds conflict" warning to client keybind options
- Keybinding cancellation hotkey moved from "Escape" to "Shift+Escape" so that Escape can be bound. (If you want to bind something to Shift+Escape you're insane)
- The matchmaker popup is now above krunker windows
- The matchmaker popup is now hidden while in-game
- Matchmaker keybinds no longer fire when pointerlock is active (Matchmaker cannot be interacted with while in-game)