### PR TITLE
Fixes Mac Arm64 Freeze Bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"concurrently": "^9.1.2",
 		"conventional-changelog-cli": "^5.0.0",
 		"electron-builder": "23.6.0",
-		"electron": "npm:electron-nightly@12.0.0-nightly.20201116",
+		"electron": "^13.6.9",
 		"esbuild": "^0.25.1",
 		"eslint": "^8.56.0",
 		"eslint-config-airbnb-typescript": "^17.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0(conventional-commits-filter@5.0.0)
       electron:
-        specifier: npm:electron-nightly@12.0.0-nightly.20201116
-        version: electron-nightly@12.0.0-nightly.20201116
+        specifier: ^13.6.9
+        version: 13.6.9
       electron-builder:
         specifier: 23.6.0
         version: 23.6.0
@@ -888,11 +888,6 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
-  electron-nightly@12.0.0-nightly.20201116:
-    resolution: {integrity: sha512-4sIzOchbGhBqoOVd3592xe3H01lMbtipRfBHsS75tJvlsGB4JdypGC9TdoeLcCNphG3Hm7HvnIvZsfHxXUFSuQ==}
-    engines: {node: '>= 8.6'}
-    hasBin: true
-
   electron-osx-sign@0.6.0:
     resolution: {integrity: sha512-+hiIEb2Xxk6eDKJ2FFlpofCnemCbjbT5jz+BKGpVBrRNT3kWTGs4DfNX6IzGwgi33hUcXF+kFs9JW+r6Wc1LRg==}
     engines: {node: '>=4.0.0'}
@@ -901,6 +896,11 @@ packages:
 
   electron-publish@23.6.0:
     resolution: {integrity: sha512-jPj3y+eIZQJF/+t5SLvsI5eS4mazCbNYqatv5JihbqOstIM13k0d1Z3vAWntvtt13Itl61SO6seicWdioOU5dg==}
+
+  electron@13.6.9:
+    resolution: {integrity: sha512-Es/sBy85NIuqsO9MW41PUCpwIkeinlTQ7g0ainfnmRAM2rmog3GBxVCaoV5dzEjwTF7TKG1Yr/E7Z3qHmlfWAg==}
+    engines: {node: '>= 8.6'}
+    hasBin: true
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -3052,14 +3052,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-nightly@12.0.0-nightly.20201116:
-    dependencies:
-      '@electron/get': 1.14.1
-      '@types/node': 14.14.45
-      extract-zip: 1.7.0
-    transitivePeerDependencies:
-      - supports-color
-
   electron-osx-sign@0.6.0:
     dependencies:
       bluebird: 3.7.2
@@ -3080,6 +3072,14 @@ snapshots:
       fs-extra: 10.1.0
       lazy-val: 1.0.5
       mime: 2.6.0
+    transitivePeerDependencies:
+      - supports-color
+
+  electron@13.6.9:
+    dependencies:
+      '@electron/get': 1.14.1
+      '@types/node': 14.14.45
+      extract-zip: 1.7.0
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
switches from that nightly electron version to 13.6.9


also im pretty sure this should be the same as 13.0.0 but idk teehee im immature

electron <12 uses rosetta 2 instead of native arm64 so i just guessed i should try 13

also why were we using a nightly version of electron
also i probably broke something without realizing it with a different electron version but yea