### PR TITLE
hopefully fixed the splash screen not clearing issue

### DIFF
--- a/src/preload.ts
+++ b/src/preload.ts
@@ -351,8 +351,8 @@ ipcRenderer.on('injectClientCSS', (_event, _userPrefs: UserPrefs, version: strin
 
 		const observeInstructions = () => {
 			observer.observe(document.getElementById('instructions'), observerConfig);
-		}
-		
+		};
+
 		if(document.readyState === "loading") {
 			window.addEventListener("DOMContentLoaded", observeInstructions);
 		} else {


### PR DESCRIPTION
![img](https://media.discordapp.net/attachments/967554379697758218/1444635946103603313/image.png?ex=692d6d91&is=692c1c11&hm=9667213ab98ad442f2854905c60ec1b9c3aae6381e8b3775a7bf797508e25a70&=&format=webp&quality=lossless)

`pointerlockchange` failsafe is above the `observer.observe(...)` now so it actually runs if `observer.observe(...)` fails, though that should not happen now as,
the instructions div that was `null` before (not of type Node) is now verified using a `setInterval`.